### PR TITLE
support http auth

### DIFF
--- a/root/etc/services.d/c9/run
+++ b/root/etc/services.d/c9/run
@@ -3,4 +3,4 @@
 cd /c9sdk
 HOME=/c9bins exec \
 	s6-setuidgid abc \
-	/c9bins/.c9/node/bin/node server.js --listen 0.0.0.0 -p 8000 -w /code -a :
+	/c9bins/.c9/node/bin/node server.js --listen 0.0.0.0 -p 8000 -w /code -a "${USERNAME}:${PASSWORD}"


### PR DESCRIPTION
Did basic tests. It works when USERNAME and PASSWORD are set with auth, and it works without auth if they are unset.

If this is merged, I'll PR readme updates to the downstream images for the optional env vars.

closes https://github.com/linuxserver/docker-cloud9/issues/7